### PR TITLE
Changed HubProxy::invoke methods to accept QVariant & QVariantList inste...

### DIFF
--- a/SignalRLibraries/SignalRClient/Hubs/HubProxy.cpp
+++ b/SignalRLibraries/SignalRClient/Hubs/HubProxy.cpp
@@ -41,15 +41,12 @@ HubProxy::~HubProxy()
 {
 }
 
-void HubProxy::invoke(QString method, QString param, HubCallback* callback)
+void HubProxy::invoke(QString method, QVariant param, HubCallback* callback)
 {
-    QStringList params;
-    params.append(param);
-    invoke(method, params, callback);
-
+    invoke(method, QVariantList() << param, callback);
 }
 
-void HubProxy::invoke(QString method, QStringList params, HubCallback* callback)
+void HubProxy::invoke(QString method, QVariantList params, HubCallback* callback)
 {
     QVariantMap map;
     map.insert("A", params);

--- a/SignalRLibraries/SignalRClient/Hubs/HubProxy.h
+++ b/SignalRLibraries/SignalRClient/Hubs/HubProxy.h
@@ -45,8 +45,12 @@ public:
     HubProxy(HubConnection* connection, QString hubName);
     ~HubProxy();
 
-    void invoke(QString method, QString param, HubCallback*);
-    void invoke(QString method, QStringList params,HubCallback*);
+    void invoke(QString method, QVariant param, HubCallback* callback = 0);
+    void invoke(QString method, QVariantList params, HubCallback* callback = 0);
+    void invoke(QString method, HubCallback* callback = 0)
+    {
+        invoke(method, QVariantList(), callback);
+    }
 
     void onReceive(QVariant var);
 


### PR DESCRIPTION
...ad of QString & QStringList.  Also added default null value for the HubCallback and a convenience overload of invoke for void(void) calls.

Please consider this slight change.  I think this will allow for richer parameter passing to the hub, without having to stringize everything manually.  For instance, instead of 

```
prox->invoke("JoinGroup", "110.110", callback);
```

you can now do 

```
prox->invoke("JoinGroup", 110.110, callback);
```

ok, maybe that example isn't real impressive :)

Something like this is now possible:

```
prox->invoke("JoinGroup", QVariantList() << 110.110 << "foo" << 777, callback);
```

if you wanted to do such a thing.  You should also be able to pass lists (this is my primary motivation for making the change).  Pretty much anything that QtExtJson can deal with.

Note: My expectation is that this is not a breaking change, and should be fully backwards compatible with existing code.

(Thanks for creating this library! It's been really helpful to me.)
